### PR TITLE
Configure upload directory via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Crie `apps/backend/.env` baseado em `.env.example`.
 
 - Para SQLite (padrão dev): `DATABASE_URL="file:./dev.db"`
 - Para Postgres (Render): ex: `DATABASE_URL="postgresql://user:pass@host:5432/db?schema=public"`
+- Para uploads: `UPLOAD_DIR` (opcional). Em servidores serverless (ex.: Vercel) configure para `"/tmp"` ou utilize um armazenamento externo (S3, etc.).
 
 ## Deploy (Render)
 - O repositório inclui um `render.yaml` com dois serviços: API (Node) e frontend (Static Site). Basta importá-lo no Render para criar ambos automaticamente.

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,22 +1,19 @@
 import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
-import multer from 'multer';
-import path from 'path';
-import fs from 'fs';
 import { prisma } from './db';
 import processesRouter from './routes/processes';
 import catalogsRouter from './routes/catalogs';
 import importRouter from './routes/importer';
 import exportRouter from './routes/exporter';
+import { resolveUploadDir } from './uploadConfig';
 
 const app = express();
 app.use(express.json());
 app.use(cors({ origin: process.env.ORIGIN || '*' }));
 
 // Ensure upload dir
-const uploadDir = path.join(process.cwd(), 'uploads');
-if (!fs.existsSync(uploadDir)) fs.mkdirSync(uploadDir, { recursive: true });
+const uploadDir = resolveUploadDir();
 
 app.use('/api/processes', processesRouter);
 app.use('/api/catalogs', catalogsRouter);

--- a/apps/backend/src/routes/importer.ts
+++ b/apps/backend/src/routes/importer.ts
@@ -6,11 +6,14 @@ import fs from 'fs';
 import { parse as parseCsv } from 'csv-parse/sync';
 import xlsx from 'xlsx';
 import { prisma } from '../db';
+import { resolveUploadDir } from '../uploadConfig';
 
 const r = Router();
 
+const uploadDir = resolveUploadDir();
+
 const upload = multer({
-  dest: path.join(process.cwd(), 'uploads'),
+  dest: uploadDir,
   limits: { fileSize: 20 * 1024 * 1024 }, // 20MB
   fileFilter: (req, file, cb) => {
     const ext = path.extname(file.originalname).toLowerCase();

--- a/apps/backend/src/uploadConfig.ts
+++ b/apps/backend/src/uploadConfig.ts
@@ -1,0 +1,42 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+function isPathWritable(dir: string): boolean {
+  const target = fs.existsSync(dir) ? dir : path.dirname(dir);
+  try {
+    fs.accessSync(target, fs.constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function ensureDirectory(dir: string) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+export function resolveUploadDir(): string {
+  const envDir = process.env.UPLOAD_DIR?.trim();
+  const fallbackDir = os.tmpdir();
+
+  if (envDir) {
+    const resolvedEnvDir = path.resolve(envDir);
+    if (isPathWritable(resolvedEnvDir)) {
+      ensureDirectory(resolvedEnvDir);
+      return resolvedEnvDir;
+    }
+    console.warn(
+      `Upload directory "${resolvedEnvDir}" is not writable. Falling back to system temporary directory.`,
+    );
+  }
+
+  if (isPathWritable(fallbackDir)) {
+    ensureDirectory(fallbackDir);
+    return fallbackDir;
+  }
+
+  throw new Error('No writable directory available for uploads.');
+}


### PR DESCRIPTION
## Summary
- resolve the backend upload directory from the UPLOAD_DIR environment variable with a system temp fallback
- share the resolved directory with the importer route and only create writable paths
- document the new UPLOAD_DIR guidance for local and serverless deployments

## Testing
- npm run build --workspace=@cphpm/backend

------
https://chatgpt.com/codex/tasks/task_e_68d6d675b5088332b46de15ff0db8ce4