### PR TITLE
fix: align backend ESM imports with emitted files

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,12 +1,12 @@
 import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
-import { prisma } from './db';
-import processesRouter from './routes/processes';
-import catalogsRouter from './routes/catalogs';
-import importRouter from './routes/importer';
-import exportRouter from './routes/exporter';
-import { resolveUploadDir } from './uploadConfig';
+import { prisma } from './db.js';
+import processesRouter from './routes/processes.js';
+import catalogsRouter from './routes/catalogs.js';
+import importRouter from './routes/importer.js';
+import exportRouter from './routes/exporter.js';
+import { resolveUploadDir } from './uploadConfig.js';
 
 const app = express();
 app.use(express.json());

--- a/apps/backend/src/routes/catalogs.ts
+++ b/apps/backend/src/routes/catalogs.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { prisma } from '../db';
+import { prisma } from '../db.js';
 
 const r = Router();
 

--- a/apps/backend/src/routes/exporter.ts
+++ b/apps/backend/src/routes/exporter.ts
@@ -1,6 +1,6 @@
 
 import { Router } from 'express';
-import { prisma } from '../db';
+import { prisma } from '../db.js';
 import { Parser as CsvParser } from 'json2csv';
 import xlsx from 'xlsx';
 

--- a/apps/backend/src/routes/importer.ts
+++ b/apps/backend/src/routes/importer.ts
@@ -5,8 +5,8 @@ import path from 'path';
 import fs from 'fs';
 import { parse as parseCsv } from 'csv-parse/sync';
 import xlsx from 'xlsx';
-import { prisma } from '../db';
-import { resolveUploadDir } from '../uploadConfig';
+import { prisma } from '../db.js';
+import { resolveUploadDir } from '../uploadConfig.js';
 
 const r = Router();
 

--- a/apps/backend/src/routes/processes.ts
+++ b/apps/backend/src/routes/processes.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { prisma } from '../db';
+import { prisma } from '../db.js';
 
 const r = Router();
 

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -4,8 +4,8 @@
     "lib": [
       "ES2020"
     ],
-    "module": "ES2020",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "dist",
     "rootDir": "src",
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
- add .js extensions to backend relative imports so the emitted files resolve correctly
- configure the backend TypeScript compiler for NodeNext module resolution to support the new import specifiers

## Testing
- npm run build --workspace=@cphpm/backend
- node apps/backend/dist/index.js *(fails: requires prisma generate and remote engine download is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e75d95c08332a737422f994a7448